### PR TITLE
Fix empty for loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pypage
 ======
 
-[![Travis CI Build Status (Functional Tests)](https://travis-ci.org/arjungmenon/pypage.svg?branch=master)](https://travis-ci.org/arjungmenon/pypage)
+[![Travis CI Build Status (Functional Tests)](https://travis-ci.org/novarc/pypage.svg?branch=master)](https://travis-ci.org/novarc/pypage)
 
 pypage is a document templating engine for Python programmers with a short learning curve.
 

--- a/pypage.py
+++ b/pypage.py
@@ -201,7 +201,8 @@ class ForBlock(BlockTag):
                 break
 
         for target in self.targets:
-            del pe.env[target]
+            if target in pe.env:
+                del pe.env[target]
 
         pe.env.update(backup)
 

--- a/tests/For-Loop-Test-0-Empty.in.txt
+++ b/tests/For-Loop-Test-0-Empty.in.txt
@@ -1,0 +1,9 @@
+{{
+  things_i_hate = []
+}}
+Here is a list of the things I hate:
+{% for thing in things_i_hate %}
+  - {{thing}}
+{% %}
+
+Well, apparently I like everything !

--- a/tests/For-Loop-Test-0-Empty.out.txt
+++ b/tests/For-Loop-Test-0-Empty.out.txt
@@ -1,0 +1,3 @@
+Here is a list of the things I hate:
+
+Well, apparently I like everything !


### PR DESCRIPTION
When a for loop ends without any iteration (e.g. on an empty list), it tries to discard nonexistent loop variables from the environment.
